### PR TITLE
Recommend running cppcheck for each release.

### DIFF
--- a/release-tasks
+++ b/release-tasks
@@ -180,17 +180,22 @@ Contributors for 8.2:
 
 0/ Do some basic testing as always
 
+0a/ Rerun cppcheck across the source files:
+    cppcheck --force -j4 --enable=all -I./include/ ./source/*/*.cc >cppcheck-results.txt 2>&1
 
-0a/ Run the indentation script:
+    and look for anything that should obviously be fixed.
+
+
+0b/ Run the indentation script:
       ./contrib/utilities/indent
     and push the corresponding changes
 
-0b/ Check for doxygen formatting problems by running tests/scripts/checkdoxygen.py:
+0c/ Check for doxygen formatting problems by running tests/scripts/checkdoxygen.py:
       find include -name "*h" -print | xargs -n 1 ./tests/scripts/checkdoxygen.py
     and push the corresponding changes
 
 
-0c/ Fix formatting bugs reported by: 
+0d/ Fix formatting bugs reported by: 
 
     cd include;
     find . -name "*h" -print | while read file;do ../contrib/utilities/wrapcomments.py $file >temp;done
@@ -210,16 +215,16 @@ Contributors for 8.2:
     Push the corresponding changes.
 
 
-0d/ Check that doxygen produces no errors when generating offline docs.
+0e/ Check that doxygen produces no errors when generating offline docs.
     Especially check that the tutorial dot graph gets generated
 
 
-0d'/ Run the copyright script:
+0e'/ Run the copyright script:
       ./contrib/utilities/update-copyright
     and push the corresponding changes
 
 
-0e/ update Trilinos and PETSc to the latest release on the tester and update the blurb at:
+0f/ update Trilinos and PETSc to the latest release on the tester and update the blurb at:
     doc/external-libs/trilinos.html
     doc/external-libs/petsc.html
 


### PR DESCRIPTION
As was mentioned in #3108: it would be worthwhile for someone to run cppcheck and fix any obvious mistakes before each release. Running cppcheck with continuous integration is a bit much (it takes too long and there are too many false positives).