### PR TITLE
Modified cache section: added compute point location information

### DIFF
--- a/9.0/paper.tex
+++ b/9.0/paper.tex
@@ -242,8 +242,11 @@ not changed. The cache is marked for update by the \texttt{Triangulation} itself
 using signals so that data is properly invalidated upon mesh
 refinement and coarsening.
 
-Some of the methods in \texttt{GridTools} already use this cache to
-speed up repeated calls to the same expensive methods.
+Some of the methods in \texttt{GridTools} and \texttt{FEFieldFunction} already
+use this cache to avoid repeated calls to the same expensive methods.
+This results in important speed-ups for computationally heavy methods like
+\texttt{GridTools::compute\_point\_locations}.
+
 \item A new \texttt{MeshWorker::mesh\_loop} function has been added that
   performs the same tasks of the \texttt{MeshWorker::loop} function without
   forcing the users to adhere to a specific interface.


### PR DESCRIPTION
Sorry everyone, I am unspeakably late; but I believe it's better late than never.

This is a small change to the Cache section (since I also modified FeFieldFunction and I did a bit of work showing the speed ups of compute point location I think a line can be added) and I think it's worth adding it.

I will add another PR soon, with two lines on bounding boxes and distributed cpt location (which might be less important).

Best,
Giovanni