### PR TITLE
Add context for the NedelecSZ element

### DIFF
--- a/9.1/paper.tex
+++ b/9.1/paper.tex
@@ -255,6 +255,21 @@ that we briefly outline in the remainder of this section:
   assigning a globally defined orientation to local edges and faces. A
   detailed overview of the implementation of the \texttt{FE\_NedelecSZ}
   element in \dealii{} can be found in \cite{Kynch2017}.
+  
+  \textbf{
+  Matthias. These are suggestions. Feel free to ignore them. I'm planing
+  to do maxwell simulations with \dealii{} and I would like to understand
+  the advantages of NedelecSZ.
+  \begin{itemize}
+  \item I'm not sure what is wrong
+  with the former Nedelec element. Is it correct what I wrote? Feel free
+  to edit it.
+  \item This new NedelecSZ element works with adaptive mesh refinement?
+  \item If it does not work with hanging nodes. Would it be possible to
+  explain in a couple of sentences what is left to make it work with
+  hanging nodes?.
+  \end{itemize}
+  }
 
 \item All of the elementary geometrical objects of the library (namely
   \texttt{Point<dim>}, \texttt{Segment<dim>}, and

--- a/9.1/paper.tex
+++ b/9.1/paper.tex
@@ -242,9 +242,14 @@ that we briefly outline in the remainder of this section:
   N{\'e}d{\'e}lec element on quadrilaterals and hexahedra. It is based on
   the work of Zaglmayr \cite{Zag06} and overcomes the sign conflict issues
   present in traditional N{\'e}d{\'e}lec elements that arise from the edge
-  and face parameterizations used in the basis functions. Therefore, this
+  and face parameterizations used in the basis functions.
+  Because of the sign conflict it is only possible to use the traditional
+  N{\'e}d{\'e}lec element either in a grid configuration or in a complex
+  tetrahedra mesh configuration. It is not possible to use traditional
+  N{\'e}d{\'e}lec in a complex hexahedra mesh configuration. This
   element should provide consistent results for general quadrilateral and
-  hexahedral elements for which the relative orientations of edges and
+  hexahedral elements in a complex mesh configuration
+  for which the relative orientations of edges and
   faces (as seen from all adjacent cells) are often difficult to establish.
   The \texttt{FE\_NedelecSZ} element addresses the sign conflict problem by
   assigning a globally defined orientation to local edges and faces. A


### PR DESCRIPTION
@tamiko I would like to do maxwell simulations with deal.ii. It would be good to explain a little bit more what is wrong with the former Nedelec element and in which cases the former Nedelec element leads to wrong results.

Is it possible to use adaptive mesh refinement with the new NedelecSZ element?