### PR TITLE
Removed p4est reference for variable data transfer.

### DIFF
--- a/9.2/paper.tex
+++ b/9.2/paper.tex
@@ -409,7 +409,7 @@ following:
 \item nanoflann \cite{nanoflann}
 \item NetCDF \cite{rew1990netcdf}
 \item OpenCASCADE \cite{opencascade-web-page}
-\item p4est \cite{Burstedde2018,p4est}
+\item p4est \cite{p4est}
 \item PETSc \cite{petsc-user-ref,petsc-web-page}
 \item ROL \cite{ridzal2014rapid}
 \item ScaLAPACK \cite{slug}


### PR DESCRIPTION
Open for discussion: Since the transfer of data during the adaptation of `parallel::distributed::Triangulation` objects was a topic of the 9.1 release, we no longer have to mention the corresponding `p4est` publication in the list of libraries for which deal.II has interfaces. We don't mention `p4est` publications that elaborate on other features that we use as well.