### PR TITLE
Update PETSc/Trilinos references.

### DIFF
--- a/9.3/paper.bib
+++ b/9.3/paper.bib
@@ -467,8 +467,8 @@ Collection of deal.II Manifold Wrappers for the OpenCASCADE Library}},
 @Misc{trilinos-web-page,
      Author      = "M. A. Heroux and others",
     Title      = "{Trilinos} web page",
-    Note     = "\url{http://trilinos.org}",
-    Year     = "2018"}
+    Note     = "\url{https://trilinos.org}",
+    Year     = "2021"}
 
 # From http://www.mcs.anl.gov/petsc/documentation/referencing.html
 @Misc{petsc-web-page,

--- a/9.3/paper.bib
+++ b/9.3/paper.bib
@@ -472,31 +472,31 @@ Collection of deal.II Manifold Wrappers for the OpenCASCADE Library}},
 
 # From http://www.mcs.anl.gov/petsc/documentation/referencing.html
 @Misc{petsc-web-page,
-            author = {S. Balay and S. Abhyankar and M.~F. Adams and J. Brown and P. Brune
-                      and K. Buschelman and L. Dalcin and V. Eijkhout and W.~D. Gropp
-                      and D. Karpeyev and D. Kaushik and M.~G. Knepley
-                      and D. May and L. Curfman McInnes and R. Mills and T. Munson
-                      and K. Rupp and P. Sanan B.~F. Smith and S. Zampini
-                      and H. Zhang and H. Zhang},
-            title =  {{PETS}c {W}eb page},
-            url =    {http://www.mcs.anl.gov/petsc},
-            howpublished = {\url{http://www.mcs.anl.gov/petsc}},
-            year = {2018}
-          }
+  author = {S. Balay and S. Abhyankar and M.~F. Adams and J. Brown and P. Brune
+            and K. Buschelman and L. Dalcin and V. Eijkhout and W.~D. Gropp
+            and D. Karpeyev and D. Kaushik and M.~G. Knepley
+            and D. May and L. Curfman McInnes and R. Mills and T. Munson
+            and K. Rupp and P. Sanan B.~F. Smith and S. Zampini
+            and H. Zhang and H. Zhang},
+  title =  {{PETS}c {W}eb page},
+  url =    {https://www.mcs.anl.gov/petsc},
+  howpublished = {\url{https://www.mcs.anl.gov/petsc}},
+  year = {2021}
+}
 
 @TechReport{petsc-user-ref,
-            author = {S. Balay and S. Abhyankar and M.~F. Adams and J. Brown and P. Brune
-                      and K. Buschelman and L. Dalcin and V. Eijkhout and W.~D. Gropp
-                      and D. Karpeyev and D. Kaushik and M.~G. Knepley
-                      and D. May and L. Curfman McInnes and R. Mills and T. Munson
-                      and K. Rupp and P. Sanan B.~F. Smith and S. Zampini
-                      and H. Zhang and H. Zhang},
-            title  = {{PETS}c Users Manual},
-            institution = {Argonne National Laboratory},
-            year   = 2018,
-            number = {ANL-95/11 - Revision 3.9},
-            url    = {http://www.mcs.anl.gov/petsc}
-          }
+  author = {S. Balay and S. Abhyankar and M.~F. Adams and J. Brown and P. Brune
+            and K. Buschelman and L. Dalcin and V. Eijkhout and W.~D. Gropp
+            and D. Karpeyev and D. Kaushik and M.~G. Knepley
+            and D. May and L. Curfman McInnes and R. Mills and T. Munson
+            and K. Rupp and P. Sanan B.~F. Smith and S. Zampini
+            and H. Zhang and H. Zhang},
+  title  = {{PETS}c Users Manual},
+  institution = {Argonne National Laboratory},
+  year   = 2021,
+  number = {ANL-95/11 - Revision 3.15},
+  url    = {https://www.mcs.anl.gov/petsc}
+}
 
 
 @Article{umfpack,


### PR DESCRIPTION
See https://www.mcs.anl.gov/petsc/documentation/referencing.html

Do you want to keep the first names abbreviated, or shall we switch to the full ones?