### PR TITLE
Skip dependabot[bot].

### DIFF
--- a/release-tasks
+++ b/release-tasks
@@ -111,7 +111,7 @@ Best
            sort |uniq
 
      Compare with the commit list:
-       git log --date=short --format="%an %aE" v8.5.0..HEAD | sort | uniq
+       git log --date=short --format="%an %aE" v8.5.0..HEAD | grep -v 'dependabot\[bot\]' | sort | uniq
 
 
 


### PR DESCRIPTION
Other half of https://github.com/dealii/dealii/pull/13785 - dependabot doesn't get to be a deal.II author.