### PR TITLE
Renumber author affiliations.

### DIFF
--- a/9.4/paper.tex
+++ b/9.4/paper.tex
@@ -104,58 +104,58 @@ cross/.default={2pt}}
 
 \author[2]{Marc~Fehling}
 
-\author[13]{Rene~Gassm{\"o}ller}
-\affil[13]{Department of Geological Sciences,
+\author[5]{Rene~Gassm{\"o}ller}
+\affil[5]{Department of Geological Sciences,
    University of Florida,
    1843 Stadium Road,
    Gainesville, FL, 32611, USA.
   {\texttt{rene.gassmoeller@ufl.edu}}}
 
-\author[5]{Timo~Heister}
- \affil[5]{School of Mathematical and Statistical Sciences,
+\author[6]{Timo~Heister}
+ \affil[6]{School of Mathematical and Statistical Sciences,
    Clemson University,
    Clemson, SC, 29634, USA
    {\texttt{heister@clemson.edu}}}
 
 \author[4]{Luca~Heltai}
 
- \author[6,7]{Martin~Kronbichler}
- \affil[6]{Department of Information Technology,
+ \author[7,8]{Martin~Kronbichler}
+ \affil[7]{Department of Information Technology,
    Uppsala University,
    Box 337, 751\,05 Uppsala, Sweden.
    {\texttt{martin.kronbichler/simon.sticko@it.uu.se}}}
- \affil[7]{Institute of Mathematics,
+ \affil[8]{Institute of Mathematics,
    University of Augsburg,
    Universit\"atsstr.~12a, 86159 Augsburg, Germany.
    {\texttt{martin.kronbichler@uni-a.de}}}
 
-\author[8]{Matthias~Maier}
-\affil[8]{Department of Mathematics,
+\author[9]{Matthias~Maier}
+\affil[9]{Department of Mathematics,
   Texas A\&M University,
   3368 TAMU,
   College Station, TX 77845, USA.
   {\texttt{maier@math.tamu.edu}}}
 
-\author[7,9]{Peter Munch}
- \affil[9]{Institute of Material Systems Modeling,
+\author[8,10]{Peter Munch}
+ \affil[10]{Institute of Material Systems Modeling,
  Helmholtz-Zentrum Hereon,
  Max-Planck-Str. 1, 21502 Geesthacht, Germany.
    {\texttt{peter.muench@hereon.de}}}
 
 
-\author[10]{Jean-Paul~Pelteret}
-\affil[10]{Independent researcher.
+\author[11]{Jean-Paul~Pelteret}
+\affil[11]{Independent researcher.
 {\texttt{jppelteret@gmail.com}}}
 
-\author[6,11]{Simon~Sticko}
-\affil[11]{Department of Mathematics and Mathematical Statistics,
+\author[7,12]{Simon~Sticko}
+\affil[12]{Department of Mathematics and Mathematical Statistics,
    Umeå University,
    SE-90187 Umeå, Sweden}
 
 \author[1*]{Bruno~Turcksin}
 
-\author[12]{David Wells}
-\affil[12]{Department of Mathematics, University of North Carolina,
+\author[13]{David Wells}
+\affil[13]{Department of Mathematics, University of North Carolina,
   Chapel Hill, NC 27516, USA.
   {\texttt{drwells@email.unc.edu}}}
 


### PR DESCRIPTION
Noticed that Rene's affiliation was missing from the affiliation list. Apparently the affiliations need to numbered increasingly in the order they appear in the file.
![Screenshot from 2022-06-23 17-16-33](https://user-images.githubusercontent.com/9609727/175335799-a4fb6d17-8080-449d-8a6d-73c9a9422741.png)
