### PR TITLE
Remove reference to deal.II-FROSch interface.

### DIFF
--- a/9.6/paper.tex
+++ b/9.6/paper.tex
@@ -536,9 +536,6 @@ allowing users familiar with both to write `pure' \trilinos{} code within their
 applications, e.g.\ to test or develop a new feature.
 Therefore, the internal data is stored as it would be in a \trilinos{} 
 application code (as \texttt{Teuchos::RCP}) and can be accessed through member functions. 
-In fact, one of the authors has already used this to apply the domain decomposition preconditioner
-\texttt{FROSch} to various problems discretized using \dealii{}.
-\todo[inline]{Kinnewig: Add citation to preprint?}
 
 Finally,
 all \texttt{TpetraWrappers} classes take \texttt{Number} and \texttt{MemorySpace} template arguments,


### PR DESCRIPTION
The paper in question has not been published yet. I plan to create a PR for the FROSch wrapper in the future, so let's remove this for the moment.