### PR TITLE
Add name and affiliation for Vladimir Ivannikov

### DIFF
--- a/9.8/paper.tex
+++ b/9.8/paper.tex
@@ -91,6 +91,7 @@ cross/.default={2pt}}
     Rene Gassm\"{o}ller,
     Timo Heister,
     Luca Heltai,
+    Vladimir Ivannikov,
     Martin Kronbichler,
     Matthias Maier,
     Peter Munch,
@@ -143,26 +144,30 @@ cross/.default={2pt}}
 \affil[9]{Department of Mathematics, University of Pisa,
 Via Buonarroti 1/c, 56127 Pisa, Italy. {\texttt{luca.heltai@unipi.it}}}
 
-\author[10]{Martin~Kronbichler}
-\affil[10]{Faculty of Mathematics, Ruhr University Bochum,
+\author[10]{Vladimir~Ivannikov}
+\affil[10]{Institute of Material Systems Modeling, Helmholtz-Zentrum Hereon,
+Max-Planck-Stra{\ss}e 1, 21502 Geesthacht, Germany. {\texttt{vladimir.ivannikov@hereon.de}}}
+
+\author[11]{Martin~Kronbichler}
+\affil[11]{Faculty of Mathematics, Ruhr University Bochum,
    Universit\"atsstr.~150, 44780 Bochum, Germany.
  {\texttt{martin.kronbichler@rub.de}}}
 
-\author[11]{Matthias~Maier}
-\affil[11]{Department of Mathematics,
+\author[12]{Matthias~Maier}
+\affil[12]{Department of Mathematics,
   Texas A\&M University,
   3368 TAMU,
   College Station, TX 77845, USA.
   {\texttt{maier@math.tamu.edu}}}
 
-\author[12]{Peter Munch}
-\affil[12]{Institute of Mathematics, Technical University of Berlin, Germany.
+\author[13]{Peter Munch}
+\affil[13]{Institute of Mathematics, Technical University of Berlin, Germany.
   {\texttt{muench@math.tu-berlin.de}}}
 
 \author[1*]{Bruno~Turcksin}
 
-\author[14]{David Wells}
-\affil[14]{Department of Mathematics, University of North Carolina,
+\author[15]{David Wells}
+\affil[15]{Department of Mathematics, University of North Carolina,
   Chapel Hill, NC 27516, USA.
   {\texttt{drwells@email.unc.edu}}}
 


### PR DESCRIPTION
@bangerth, I have added myself to the authors list and added my affiliation.

Just in case you find it helpful, here is the summary of the `ARKODE` related changes that could be added to the paper. I did not add this text to the PR itself in case you prefer to have it written differently.

--------------------

The interface to the \texttt{SUNDIALS} \texttt{ARKODE} package has been substantially reorganized. The \texttt{SUNDIALS::ARKode} class now acts as a common driver for time integration, while stepper-specific setup and callbacks have been moved into a new \texttt{ARKodeStepper} hierarchy. This mirrors the modular structure of ARKODE itself and removes the previous assumption that all time integration is performed through \texttt{ARKODE}'s \texttt{ARKStep} module. The existing implicit-explicit functionality is now provided by \texttt{ARKStepper}. To smooth the migration to the new class hierarchy, deprecated compatibility wrappers have been introduced that preserve the old interface.

This restructuring made it possible to add wrappers for further \texttt{ARKODE} modules. The new \texttt{ERKStepper} exposes the explicit \texttt{ERKStep} module for non-stiff problems. The \texttt{LSRKStepperSTS} and \texttt{LSRKStepperSSP} classes expose the low-storage Runge--Kutta \texttt{LSRKStep} module for stabilized explicit integration of mildly stiff parabolic problems and strong-stability-preserving integration of hyperbolic or advection-dominated problems, respectively.
